### PR TITLE
Update Dockerfile_rocm64_whisperx

### DIFF
--- a/rocm_6.4/Dockerfile_rocm64_whisperx
+++ b/rocm_6.4/Dockerfile_rocm64_whisperx
@@ -146,4 +146,4 @@ RUN touch whisp.sh && \
     true    
 
 EXPOSE ${WHISPERX_GUI_PORT}
-ENTRYPOINT ["/Whisper-WebUI/whisp.sh"]
+ENTRYPOINT ["/bin/bash", "/Whisper-WebUI/whisp.sh"]


### PR DESCRIPTION
Hi Robert, 

First off, thank you for your work on the Dockerfile for Whisper-WebUI with ROCm (rocm64_gfx803_base). I've been using it and found it very helpful. 

I encountered an "exec format error" when running the image built with the Dockerfile. The error message was: exec /Whisper-WebUI/whisp.sh: exec format error. 

After some troubleshooting, I found that changing the ENTRYPOINT instruction in the Dockerfile resolved the issue for me. The container now starts correctly. 

This change explicitly invokes /bin/bash to execute the whisp.sh script, which seems to bypass a potential issue with the shebang line (#!/bin/bash) interpretation or line endings within the script itself when it's created via echo commands in the Dockerfile.

I wanted to share this in case it helps others who might encounter the same problem, or if you'd consider incorporating this change into the Dockerfile for broader compatibility. 

Thanks again for your efforts! 

Best regards, 