### PR TITLE
Accept conda ToS

### DIFF
--- a/Dockerfile_rocm64_whisperx
+++ b/Dockerfile_rocm64_whisperx
@@ -81,6 +81,9 @@ RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -
     export PATH=/opt/conda/bin:$PATH &&\
     true
 
+RUN /opt/conda/bin/conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main \
+ && /opt/conda/bin/conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+
 RUN /opt/conda/bin/conda update -n base -c defaults conda &&\
     /opt/conda/bin/conda create -n py_3.12 python=3.12 &&\    
     /opt/conda/bin/conda init &&\


### PR DESCRIPTION
When building WhisperX on my Ubuntu 24.04, I encountered the following error:

> CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels. Please accept or remove them before proceeding:                                                
1.071     • https://repo.anaconda.com/pkgs/main                                                                                                                                                       
1.071     • https://repo.anaconda.com/pkgs/r

... and accepting the ToS allowed the build to continue.